### PR TITLE
Allow for constant polling period

### DIFF
--- a/jquery.periodicalupdater.js
+++ b/jquery.periodicalupdater.js
@@ -56,7 +56,7 @@
 
         // Function to boost the timer 
         var boostPeriod = function() {
-          if(settings.multiplier > 1) {
+          if(settings.multiplier >= 1) {
             before = timerInterval;
             timerInterval = timerInterval * settings.multiplier;
 


### PR DESCRIPTION
The current version of PeriodicalUpdater doesn't allow for the period multiplier to be 1.  This commit fixes that.
