### PR TITLE
fix for 304 parse error

### DIFF
--- a/jquery.periodicalupdater.js
+++ b/jquery.periodicalupdater.js
@@ -147,7 +147,7 @@
               if(remoteData == null) remoteData = rawData;
               // jQuery 1.4+ $.ajax() automatically converts "data" into a JS Object for "type:json" requests now
               // For compatibility with 1.4+ and pre1.4 jQuery only try to parse actual strings, skip when remoteData is already an Object
-              if((ajaxSettings.dataType === 'json') && (typeof(remoteData) === 'string')) {
+              if((ajaxSettings.dataType === 'json') && (typeof(remoteData) === 'string') && (success == "success")) {
                 remoteData = JSON.parse(remoteData);
               }
               if(settings.success) { settings.success(remoteData, success, xhr, handle); }


### PR DESCRIPTION
was getting a JSON parse error on 304 status since the remoteData was empty. started seeing this with jQuery 1.5
