### PR TITLE
improvements to restart()

### DIFF
--- a/jquery.periodicalupdater.js
+++ b/jquery.periodicalupdater.js
@@ -82,10 +82,11 @@
         ajaxSettings.ifModified = true;
 
         var handle = {
-            restart: function () {
+            restart: function (newInterval) {
                 maxCalls = originalMaxCalls;
                 calls = 0;
-                reset_timer(timerInterval);
+                noChange = 0;
+                reset_timer(newInterval || timerInterval);
                 return;
             },
             stop: function () {


### PR DESCRIPTION
Allow autoStop to continue working after restart.

Added the ability to reset the timeInterval with restart.
https://github.com/RobertFischer/JQuery-PeriodicalUpdater/issues/17
