### PR TITLE
Fix enqueuing of periodic call when jquery-cookie plugin is already included on the page and cookie option is unspecified.

### DIFF
--- a/jquery.periodicalupdater.js
+++ b/jquery.periodicalupdater.js
@@ -244,7 +244,7 @@
 				if (settings.runatonce) {
 					pu_log("Executing a call immediately", 1);
 					getdata(true);
-				} else if($.cookie && $.cookie(settings.cookie.name)) {
+				} else if(settings.cookie && $.cookie && $.cookie(settings.cookie.name)) {
 					// Do nothing (already handled above)
 				} else {
 					pu_log("Enqueing a the call for after " + timerInterval, 1);


### PR DESCRIPTION
This is a pretty simple fix for an issue that happens in the following case:
- The JQuery-Cookie plugin is already included on the page (and thus `$.cookie` exists).
- `$.PeriodicalUpdater()` is called with no `cookie` option set.

When these two occurred, the call would not be enqueued for periodic updating.

The cause for the bug was due to the first line here:

``` js
} else if($.cookie && $.cookie(settings.cookie.name)) {
    // Do nothing (already handled above)
} else {
    pu_log("Enqueing a the call for after " + timerInterval, 1);
    reset_timer(timerInterval);
}
```

Because `$.cookie` exists, it will attempt to call `$.cookie(settings.cookie.name)`, but because `settings.cookie` was not specified, it calls `$.cookie()` with an undefined value, which ends up returning all cookies. As a result it ends up going into the `// Do nothing` block instead of enqueuing the call.

This fix changes the `if` statement to also check that `settings.cookie` was specified first:

``` js
} else if(settings.cookie && $.cookie && $.cookie(settings.cookie.name)) {
```
